### PR TITLE
Add support to include commit hashes of branch heads in versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ resource_types:
   * `proxy_user`: *Optional.* If the proxy requires authentication, use this username
   * `proxy_password`: *Optional.* If the proxy requires authenticate,
       use this password
+      
+* `include_git_heads`: *Optional.* Include hash commit from the head of every branch. Instead of a list of branch names `["branch1", "branch2"]`, an object of commit hash -> branch key values `{"19f75c129076fb3ade144ff95225c77de04d49ee": "branch1", "cc5983bc9f3e6b4107d2a23d08099c021562df06": "branch2"}`. This can be used to apply further filtering in a following task e.g. filter versions for a specific path.
 
 ### Example
 

--- a/assets/check
+++ b/assets/check
@@ -18,6 +18,7 @@ configure_git_ssl_verification "$payload"
 configure_credentials "$payload"
 
 uri=$(jq -r '.source.uri // ""' <<< "$payload")
+include_git_heads=$(jq -r '.source.include_git_heads // ""' <<< "$payload")
 branch_regex=$(jq -r '.source.branch_regex // ""' <<< "$payload")
 prev_branches=$(jq -r '.version.branches // ""' <<< "$payload")
 git_config_payload=$(jq -r '.source.git_config // []' <<< "$payload")

--- a/assets/run-in.py
+++ b/assets/run-in.py
@@ -5,17 +5,41 @@ import sys
 
 def main():
     payload = json.loads(sys.argv[1])
-    branches = json.loads(payload['version']['branches'])
+    branches = json.loads(payload["version"]["branches"])
 
-    source = payload['source']
-    if 'branch_regex' in source:
-        regex = re.compile(source['branch_regex'])
-        output = [{'name': branch, 'groups': regex.match(branch).groupdict()} for branch in branches]
+    source = payload["source"]
+    include_git_heads = (
+        True
+        if "include_git_heads" in source and source["include_git_heads"] == "true"
+        else False
+    )
+
+    if "branch_regex" in source:
+        regex = re.compile(source["branch_regex"])
+        if include_git_heads:
+            output = [
+                {
+                    "name": branch,
+                    "head": head,
+                    "groups": regex.match(branch).groupdict(),
+                }
+                for head, branch in branches.items()
+            ]
+        else:
+            output = [
+                {"name": branch, "groups": regex.match(branch).groupdict()}
+                for branch in branches
+            ]
     else:
-        output = [{'name': branch} for branch in branches]
+        if include_git_heads:
+            output = [
+                {"name": branch, "head": head} for head, branch in branches.items()
+            ]
+        else:
+            output = [{"name": branch} for branch in branches]
 
     print(json.dumps(output))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
The data is already being fetched by the git ls-remote command and, as
an optional parameter it can be included in the versions emitted by the
resource. This unlocks further filtering by a task in the pipeline, e.g.
to filter versions that changed a specific path.