### PR TITLE
Raise exception when subprocess fails

### DIFF
--- a/assets/run-check.py
+++ b/assets/run-check.py
@@ -15,6 +15,13 @@ def main():
     uri = source['uri']
 
     result = subprocess.run(['git', 'ls-remote', '--heads', uri], stdout=subprocess.PIPE)
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            returncode=result.returncode,
+            cmd=result.args,
+            stderr=result.stderr
+        )
+
     lines = [line.strip() for line in result.stdout.decode('utf-8').split('\n') if line.strip()]
     branches = [line.split()[1].removeprefix('refs/heads/') for line in lines]
 


### PR DESCRIPTION
During a pipeline run, your resource failed to connect to github due to some internal internet issues inside the company network and did not raise this as an error causing it to return a valid but empty object. Which caused out cleanup concourse task to remove all feature branch infrastructure. 

This change is to make the check fail so that this doesn't happen again.